### PR TITLE
Adding the ability to have a image snippet linked to the files module

### DIFF
--- a/snippets/controllers/admin.php
+++ b/snippets/controllers/admin.php
@@ -198,7 +198,7 @@ class Admin extends Admin_Controller {
 		
 			$this->load->model('files/file_m');
 			$images = $this->file_m->order_by('name','ASC')->dropdown('name');
-			array_unshift($images, '-- ' . lang('snippets.snippet_image') . ' --');
+			$images[0] = '-- ' . lang('snippets.snippet_image') . ' --';
 			$this->template->set('images', $images);
 			$mode = 'incoming'; // Reset the mode to incoming because we only need the id & name
 

--- a/snippets/language/english/snippets_lang.php
+++ b/snippets/language/english/snippets_lang.php
@@ -47,5 +47,14 @@
 	$lang['snippets.snippet_type']							= 'Snippet Type';
 	$lang['snippets.snippet_content']						= 'Snippet Content';
 
+	// -------------------------------------
+	// Snippet Types
+	// -------------------------------------
+
+	$lang['snippets.snippet_wysiwyg']						= 'WYSIWYG';
+	$lang['snippets.snippet_text']							= 'Text';
+	$lang['snippets.snippet_html']							= 'HTML';
+	$lang['snippets.snippet_image']							= 'Image';
+
 /* End of file snippets_lang.php */
 /* Location: ./addons/modules/snippets/language/english/snippets_lang.php */

--- a/snippets/models/snippets_m.php
+++ b/snippets/models/snippets_m.php
@@ -148,6 +148,28 @@ class Snippets_m extends MY_Model {
 				return htmlspecialchars_decode( $string );
 			
 			endif;
+			
+		elseif ( $type == 'image' ):
+		
+			if( $mode == 'incoming' ):
+		
+				return $string;
+		
+			else:
+
+				$this->load->model('files/file_m');
+				if ($this->file_m->exists($string)):
+				
+					$image = $this->file_m->get($string);
+					
+					return '<img src="' . $image->filename . '" alt="' . $image->name . '" width="' . $image->width . '" height="' . $image->height . '" >';
+				else:
+					
+					return '';
+				
+				endif;
+		
+			endif;
 		
 		else:
 		

--- a/snippets/models/snippets_m.php
+++ b/snippets/models/snippets_m.php
@@ -158,11 +158,12 @@ class Snippets_m extends MY_Model {
 			else:
 
 				$this->load->model('files/file_m');
+				$this->load->config('files/files');
 				if ($this->file_m->exists($string)):
 				
 					$image = $this->file_m->get($string);
 					
-					return '<img src="' . $image->filename . '" alt="' . $image->name . '" width="' . $image->width . '" height="' . $image->height . '" >';
+					return '<img src="/'. $this->config->item('files_folder') . '/' . $image->filename . '" alt="' . $image->name . '" width="' . $image->width . '" height="' . $image->height . '" >';
 				else:
 					
 					return '';

--- a/snippets/views/admin/edit.php
+++ b/snippets/views/admin/edit.php
@@ -12,12 +12,19 @@
 	<div id="snippet-content-tab">
 	
 		<ol>
-
+			<?php if ($snippet->type != 'image'):?>
 			<li>
 				<label for="name"><?php echo lang('snippets.snippet_content');?></label><br />
 				<?php echo form_textarea('content', $snippet->content, 'width="400" class="wysiwyg-advanced"'); ?>
 				<span class="required-icon tooltip"><?php echo lang('required_label');?></span>
 			</li>
+			<?php else: ?>
+			<li>
+				<label for="name"><?php echo lang('snippets.snippet_'.$snippet->type);?></label><br />
+				<?php echo form_dropdown('content', $images, $snippet->content); ?>
+				<span class="required-icon tooltip"><?php echo lang('required_label');?></span>
+			</li>
+			<?php endif; ?>
 
 		</ol>
 		


### PR DESCRIPTION
Adding in the ability to have an image snippet type. Linked to the files module.

When trying to use it with the latest pyrocms development branch had to fix parent::__construct(); and $this->session->userdata('user_id');

Very simple implementation but it is a start.
