### PR TITLE
Updated slug field to use underscore instead of dash

### DIFF
--- a/js/new_snippet.js
+++ b/js/new_snippet.js
@@ -1,6 +1,6 @@
 jQuery(document).ready(function() {
 
-	pyro.generate_slug('#name', '#slug');
+	pyro.generate_slug('#name', '#slug', '_');
 
 	// Add fields
 	$('#type').change(function() {


### PR DESCRIPTION
I submitted a pull request to PyroCMS and modified generate_slug to
allow a custom separator. This will be fixed when both are released (PyroCMS 2.1 & Next version of PyroSnippets).
Until then, this is safe to include and will be ignored by javascript. Temporary fix
is to manually name like_this
